### PR TITLE
DM-28181: Pin software versions to allow dependency resolution.

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -5,14 +5,13 @@
 # After editing, update requirements/dev.txt by running:
 #     make update-deps
 
-aiohttp-devtools
-black
-coverage[toml]
-flake8
-mypy
-pre-commit
-pytest
-pytest-aiohttp
-pytest-asyncio
-requests
-testing.postgresql
+aiohttp-devtools~=0.13
+black==20.8b1
+coverage[toml]~=5.3
+flake8~=3.8
+mypy~=0.790
+pre-commit~=2.8
+pytest~=6.1
+pytest-aiohttp~=0.3
+pytest-asyncio~=0.14
+testing.postgresql~=1.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,14 +22,10 @@ attrs==20.3.0
     #   pytest
 black==20.8b1
     # via -r requirements/dev.in
-certifi==2020.12.5
-    # via requests
 cfgv==3.2.0
     # via pre-commit
 chardet==3.0.4
-    # via
-    #   aiohttp
-    #   requests
+    # via aiohttp
 click==7.1.2
     # via
     #   aiohttp-devtools
@@ -46,10 +42,8 @@ flake8==3.8.4
     # via -r requirements/dev.in
 identify==1.5.11
     # via pre-commit
-idna==2.10
-    # via
-    #   requests
-    #   yarl
+idna==3.1
+    # via yarl
 iniconfig==1.1.1
     # via pytest
 mccabe==0.6.1
@@ -99,8 +93,6 @@ pyyaml==5.3.1
     # via pre-commit
 regex==2020.11.13
     # via black
-requests==2.25.1
-    # via -r requirements/dev.in
 scramp==1.2.0
     # via pg8000
 six==1.15.0
@@ -124,8 +116,6 @@ typing-extensions==3.7.4.3
     #   aiohttp
     #   black
     #   mypy
-urllib3==1.26.2
-    # via requests
 virtualenv==20.2.2
     # via pre-commit
 watchgod==0.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,53 +4,131 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-aiohttp-devtools==0.13.1  # via -r requirements/dev.in
-aiohttp==3.7.3            # via aiohttp-devtools, pytest-aiohttp
-appdirs==1.4.4            # via black, virtualenv
-async-timeout==3.0.1      # via aiohttp
-attrs==20.3.0             # via aiohttp, pytest
-black==20.8b1             # via -r requirements/dev.in
-certifi==2020.11.8        # via requests
-cfgv==3.2.0               # via pre-commit
-chardet==3.0.4            # via aiohttp, requests
-click==7.1.2              # via aiohttp-devtools, black
-coverage[toml]==5.3       # via -r requirements/dev.in
-devtools==0.6.1           # via aiohttp-devtools
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via virtualenv
-flake8==3.8.4             # via -r requirements/dev.in
-identify==1.5.9           # via pre-commit
-idna==2.10                # via requests, yarl
-iniconfig==1.1.1          # via pytest
-mccabe==0.6.1             # via flake8
-multidict==5.0.2          # via aiohttp, yarl
-mypy-extensions==0.4.3    # via black, mypy
-mypy==0.790               # via -r requirements/dev.in
-nodeenv==1.5.0            # via pre-commit
-packaging==20.4           # via pytest
-pathspec==0.8.1           # via black
-pg8000==1.16.6            # via testing.postgresql
-pluggy==0.13.1            # via pytest
-pre-commit==2.8.2         # via -r requirements/dev.in
-py==1.9.0                 # via pytest
-pycodestyle==2.6.0        # via flake8
-pyflakes==2.2.0           # via flake8
-pygments==2.7.2           # via aiohttp-devtools
-pyparsing==2.4.7          # via packaging
-pytest-aiohttp==0.3.0     # via -r requirements/dev.in
-pytest-asyncio==0.14.0    # via -r requirements/dev.in
-pytest==6.1.2             # via -r requirements/dev.in, pytest-aiohttp, pytest-asyncio
-pyyaml==5.3.1             # via pre-commit
-regex==2020.11.13         # via black
-requests==2.25.0          # via -r requirements/dev.in
-scramp==1.2.0             # via pg8000
-six==1.15.0               # via packaging, virtualenv
-testing.common.database==2.0.3  # via testing.postgresql
-testing.postgresql==1.3.0  # via -r requirements/dev.in
-toml==0.10.2              # via black, coverage, pre-commit, pytest
-typed-ast==1.4.1          # via black, mypy
-typing-extensions==3.7.4.3  # via aiohttp, black, mypy
-urllib3==1.26.2           # via requests
-virtualenv==20.1.0        # via pre-commit
-watchgod==0.6             # via aiohttp-devtools
-yarl==1.6.3               # via aiohttp
+aiohttp-devtools==0.13.1
+    # via -r requirements/dev.in
+aiohttp==3.7.3
+    # via
+    #   aiohttp-devtools
+    #   pytest-aiohttp
+appdirs==1.4.4
+    # via
+    #   black
+    #   virtualenv
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.3.0
+    # via
+    #   aiohttp
+    #   pytest
+black==20.8b1
+    # via -r requirements/dev.in
+certifi==2020.12.5
+    # via requests
+cfgv==3.2.0
+    # via pre-commit
+chardet==3.0.4
+    # via
+    #   aiohttp
+    #   requests
+click==7.1.2
+    # via
+    #   aiohttp-devtools
+    #   black
+coverage[toml]==5.3.1
+    # via -r requirements/dev.in
+devtools==0.6.1
+    # via aiohttp-devtools
+distlib==0.3.1
+    # via virtualenv
+filelock==3.0.12
+    # via virtualenv
+flake8==3.8.4
+    # via -r requirements/dev.in
+identify==1.5.11
+    # via pre-commit
+idna==2.10
+    # via
+    #   requests
+    #   yarl
+iniconfig==1.1.1
+    # via pytest
+mccabe==0.6.1
+    # via flake8
+multidict==5.1.0
+    # via
+    #   aiohttp
+    #   yarl
+mypy-extensions==0.4.3
+    # via
+    #   black
+    #   mypy
+mypy==0.790
+    # via -r requirements/dev.in
+nodeenv==1.5.0
+    # via pre-commit
+packaging==20.8
+    # via pytest
+pathspec==0.8.1
+    # via black
+pg8000==1.16.6
+    # via testing.postgresql
+pluggy==0.13.1
+    # via pytest
+pre-commit==2.9.3
+    # via -r requirements/dev.in
+py==1.10.0
+    # via pytest
+pycodestyle==2.6.0
+    # via flake8
+pyflakes==2.2.0
+    # via flake8
+pygments==2.7.3
+    # via aiohttp-devtools
+pyparsing==2.4.7
+    # via packaging
+pytest-aiohttp==0.3.0
+    # via -r requirements/dev.in
+pytest-asyncio==0.14.0
+    # via -r requirements/dev.in
+pytest==6.2.1
+    # via
+    #   -r requirements/dev.in
+    #   pytest-aiohttp
+    #   pytest-asyncio
+pyyaml==5.3.1
+    # via pre-commit
+regex==2020.11.13
+    # via black
+requests==2.25.1
+    # via -r requirements/dev.in
+scramp==1.2.0
+    # via pg8000
+six==1.15.0
+    # via virtualenv
+testing.common.database==2.0.3
+    # via testing.postgresql
+testing.postgresql==1.3.0
+    # via -r requirements/dev.in
+toml==0.10.2
+    # via
+    #   black
+    #   coverage
+    #   pre-commit
+    #   pytest
+typed-ast==1.4.2
+    # via
+    #   black
+    #   mypy
+typing-extensions==3.7.4.3
+    # via
+    #   aiohttp
+    #   black
+    #   mypy
+urllib3==1.26.2
+    # via requests
+virtualenv==20.2.2
+    # via pre-commit
+watchgod==0.6
+    # via aiohttp-devtools
+yarl==1.6.3
+    # via aiohttp

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -17,8 +17,3 @@ git+git://github.com/lsst/daf_butler.git@master#daf_butler
 
 # Extra dependencies that should have been included by above packages
 jinja2~=2.11  # Needed by graphql-server
-
-# I would rather have this in dev.in but putting it here prevents a dependency issue
-# (seen 2021-01-04) where one package installs idna 3 and another demands idna < 3.
-# Thanks to Jonathan Sick for the suggestion.
-requests~=2.25

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -5,15 +5,20 @@
 # After editing, update requirements/main.txt by running:
 #     make update-deps
 
-aiohttp
-aiopg
-astropy
-click
-graphql-server[aiohttp]
-importlib_metadata
-safir
-sqlalchemy
+aiohttp~=3.7
+aiopg~=1.0
+astropy~=4.1
+click~=7.1
+graphql-server[aiohttp]~=3.0.0b2
+importlib_metadata~=2.0
+safir~=0.1
+sqlalchemy~=1.3
 git+git://github.com/lsst/daf_butler.git@master#daf_butler
 
 # Extra dependencies that should have been included by above packages
-jinja2  # Needed by graphql-server
+jinja2~=2.11  # Needed by graphql-server
+
+# I would rather have this in dev.in but putting it here prevents a dependency issue
+# (seen 2021-01-04) where one package installs idna 3 and another demands idna < 3.
+# Thanks to Jonathan Sick for the suggestion.
+requests~=2.25

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -19,12 +19,8 @@ async-timeout==3.0.1
     # via aiohttp
 attrs==20.3.0
     # via aiohttp
-certifi==2020.12.5
-    # via requests
 chardet==3.0.4
-    # via
-    #   aiohttp
-    #   requests
+    # via aiohttp
 click==7.1.2
     # via
     #   -r requirements/main.in
@@ -37,10 +33,8 @@ graphql-core==3.1.2
     # via graphql-server
 graphql-server[aiohttp]==3.0.0b3
     # via -r requirements/main.in
-idna==2.10
-    # via
-    #   requests
-    #   yarl
+idna==3.1
+    # via yarl
 importlib-metadata==2.1.1
     # via -r requirements/main.in
 jinja2==2.11.2
@@ -53,7 +47,7 @@ multidict==5.1.0
     # via
     #   aiohttp
     #   yarl
-numpy==1.19.4
+numpy==1.19.5
     # via
     #   astropy
     #   lsst-sphgeom
@@ -64,8 +58,6 @@ pyerfa==1.7.1.1
     # via astropy
 pyyaml==5.3.1
     # via daf-butler
-requests==2.25.1
-    # via -r requirements/main.in
 safir==0.1.0
     # via -r requirements/main.in
 sqlalchemy==1.3.22
@@ -78,8 +70,6 @@ typing-extensions==3.7.4.3
     # via
     #   aiohttp
     #   graphql-server
-urllib3==1.26.2
-    # via requests
 wrapt==1.12.1
     # via deprecated
 yarl==1.6.3

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,31 +4,85 @@
 #
 #    pip-compile --output-file=requirements/main.txt requirements/main.in
 #
-aiohttp==3.7.3            # via -r requirements/main.in, graphql-server, safir
-aiopg==1.0.0              # via -r requirements/main.in
-astropy==4.1              # via -r requirements/main.in, daf-butler
-async-timeout==3.0.1      # via aiohttp
-attrs==20.3.0             # via aiohttp
-chardet==3.0.4            # via aiohttp
-click==7.1.2              # via -r requirements/main.in, daf-butler
-git+git://github.com/lsst/daf_butler.git@master#daf_butler  # via -r requirements/main.in
-deprecated==1.2.10        # via daf-butler
-graphql-core==3.1.2       # via graphql-server
-graphql-server[aiohttp]==3.0.0b2  # via -r requirements/main.in
-idna==2.10                # via yarl
-importlib-metadata==2.0.0  # via -r requirements/main.in
-jinja2==2.11.2            # via -r requirements/main.in
-git+https://github.com/lsst/sphgeom@master  # via daf-butler
-markupsafe==1.1.1         # via jinja2
-multidict==5.0.2          # via aiohttp, yarl
-numpy==1.19.4             # via astropy, lsst-sphgeom
-psycopg2-binary==2.8.6    # via aiopg
-pyyaml==5.3.1             # via daf-butler
-safir==0.1.0              # via -r requirements/main.in
-six==1.15.0               # via structlog
-sqlalchemy==1.3.20        # via -r requirements/main.in, daf-butler
-structlog==20.1.0         # via safir
-typing-extensions==3.7.4.3  # via aiohttp, graphql-server
-wrapt==1.12.1             # via deprecated
-yarl==1.6.3               # via aiohttp
-zipp==3.4.0               # via importlib-metadata
+aiohttp==3.7.3
+    # via
+    #   -r requirements/main.in
+    #   graphql-server
+    #   safir
+aiopg==1.1.0
+    # via -r requirements/main.in
+astropy==4.2
+    # via
+    #   -r requirements/main.in
+    #   daf-butler
+async-timeout==3.0.1
+    # via aiohttp
+attrs==20.3.0
+    # via aiohttp
+certifi==2020.12.5
+    # via requests
+chardet==3.0.4
+    # via
+    #   aiohttp
+    #   requests
+click==7.1.2
+    # via
+    #   -r requirements/main.in
+    #   daf-butler
+git+git://github.com/lsst/daf_butler.git@master#daf_butler
+    # via -r requirements/main.in
+deprecated==1.2.10
+    # via daf-butler
+graphql-core==3.1.2
+    # via graphql-server
+graphql-server[aiohttp]==3.0.0b3
+    # via -r requirements/main.in
+idna==2.10
+    # via
+    #   requests
+    #   yarl
+importlib-metadata==2.1.1
+    # via -r requirements/main.in
+jinja2==2.11.2
+    # via -r requirements/main.in
+git+https://github.com/lsst/sphgeom@master
+    # via daf-butler
+markupsafe==1.1.1
+    # via jinja2
+multidict==5.1.0
+    # via
+    #   aiohttp
+    #   yarl
+numpy==1.19.4
+    # via
+    #   astropy
+    #   lsst-sphgeom
+    #   pyerfa
+psycopg2-binary==2.8.6
+    # via aiopg
+pyerfa==1.7.1.1
+    # via astropy
+pyyaml==5.3.1
+    # via daf-butler
+requests==2.25.1
+    # via -r requirements/main.in
+safir==0.1.0
+    # via -r requirements/main.in
+sqlalchemy==1.3.22
+    # via
+    #   -r requirements/main.in
+    #   daf-butler
+structlog==20.2.0
+    # via safir
+typing-extensions==3.7.4.3
+    # via
+    #   aiohttp
+    #   graphql-server
+urllib3==1.26.2
+    # via requests
+wrapt==1.12.1
+    # via deprecated
+yarl==1.6.3
+    # via aiohttp
+zipp==3.4.0
+    # via importlib-metadata


### PR DESCRIPTION
Recent attempts to run `make update` failed with one package
insisting on installing idna 3.0 and another rejecting that as too new.
Simply specifying versions for the package I directly use was not sufficient
to solve the problem; I also had to specify versions of yarl and idna.